### PR TITLE
react 15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "react": "0.14.7"
+    "react": "~15.0.0"
   },
   "devDependencies": {
     "codecov.io": "0.1.6",
@@ -46,7 +46,7 @@
     "istanbul": "0.4.2",
     "zuul": "3.9.0",
     "coffeeify": "2.0.1",
-    "react-dom": "0.14.7"
+    "react-dom": "~15.0.0"
   },
   "scripts": {
     "compile": "coffee --bare --compile --output lib/ src/",

--- a/test/react-kup.coffee
+++ b/test/react-kup.coffee
@@ -92,7 +92,7 @@ test 'build', (t) ->
     t.ok elementProducesMarkup element, """
       <div class="t">
         <div>hey</div>
-        <span>this is a t</span>
+        <!-- react-text: 3 -->this is a t<!-- /react-text -->
         <a>there</a>
       </div>
     """
@@ -157,13 +157,13 @@ test 'empty', (t) ->
     t.equal null, reactKup (k) ->
       t.end()
 
-  t.test 'produces noscript tag', (t) ->
+  t.test 'produces empty comment', (t) ->
     Class = React.createClass
       render: ->
         reactKup (k) ->
     element = React.createElement Class
     t.ok elementProducesMarkup element, """
-      <noscript></noscript>
+      <!-- react-empty: 1 -->
     """
     t.end()
 
@@ -180,7 +180,7 @@ test 'inner text content', (t) ->
     """
     t.end()
 
-  t.test 'more than one is wrapped in span', (t) ->
+  t.test 'more than one are wrapped in comments', (t) ->
     Class = React.createClass
       render: ->
         reactKup (k) ->
@@ -188,13 +188,13 @@ test 'inner text content', (t) ->
     element = React.createElement Class
     t.ok elementProducesMarkup element, """
       <div>
-        <span>inner text</span>
-        <span>another inner text</span>
+        <!-- react-text: 2 -->inner text<!-- /react-text -->
+        <!-- react-text: 3 -->another inner text<!-- /react-text -->
       </div>
     """
     t.end()
 
-  t.test 'interspersed is wrapped in span', (t) ->
+  t.test 'interspersed is wrapped in comment', (t) ->
     Class = React.createClass
       render: ->
         reactKup (k) ->
@@ -208,9 +208,9 @@ test 'inner text content', (t) ->
     t.ok elementProducesMarkup element, """
       <div>
         <span>text in span</span>
-        <span>inner text</span>
+        <!-- react-text: 3 -->inner text<!-- /react-text -->
         <br/>
-        <span>another inner text</span>
+        <!-- react-text: 5 -->another inner text<!-- /react-text -->
       </div>
     """
     t.end()


### PR DESCRIPTION
> **No more extra `<span>`s.** ReactDOM will now render plain text nodes interspersed with comment nodes that are used for demarcation. This gives us the same ability to update individual pieces of text, without creating extra nested nodes. If you were targeting these <span>s in your CSS, you will need to adjust accordingly. You can always render them explicitly in your components.

https://github.com/facebook/react/blob/master/CHANGELOG.md#1500-april-7-2016
- handle breaking changes in    13e2d0e - fixes #5 
- switch `react` and `react-dom` dependencies to semver minor
